### PR TITLE
changed migrate jobs to use async package and exit on completed migration

### DIFF
--- a/bin/east
+++ b/bin/east
@@ -5,7 +5,8 @@
 var program = require('commander'),
 	Migrator = require('../lib/migrator'),
 	path = require('path'),
-	utils = require('../lib/utils');
+	utils = require('../lib/utils'),
+	async = require("async");
 
 
 program
@@ -114,8 +115,8 @@ program
 			if (!params.command.silent) {
 				console.log('target migrations:\n\t' + names.join('\n\t'));
 			}
-			var funcs = names.map(function(name, index) {
-				return function() {
+			var funcs = names.map(function(name) {
+				return function(done) {
 					if (!params.command.silent) {
 						console.log('migrate `' + name + '`');
 					}
@@ -127,17 +128,18 @@ program
 							if (!params.command.silent) {
 								console.log('migration done');
 							}
-							// call next
-							if (index < funcs.length - 1) funcs[++index]();
+							done()
 						});
 					});
 				};
 			});
-			funcs.push(function() {
-				migrator.disconnect();
+			funcs.push(function(done) {
+				migrator.disconnect(done);
 			});
-			// starts migrations execution
-			funcs[0]();
+			async.series(funcs, function(){
+				console.log("jobs completed")
+				process.exit()
+			})
 		}
 	});
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 	},
 	"dependencies": {
 		"commander": "1.1.1",
-		"progress": "1.1.2"
+		"progress": "1.1.2",
+		"async":"1.4.2"
 	},
 	"devDependencies": {
 		"mocha": "1.9.0",


### PR DESCRIPTION
Thanks for this package, its going to be very useful for us at https://github.com/sharelatex/sharelatex

I had the problem where running migrate would not exit after completion of all migrations. I needed this because other jobs follow upon completion. You can see the simple change I made, we have found this pattern very robust for processing batches of work, it is used all over our stack.

I am not sure if the process.exit on https://github.com/okv/east/compare/master...henryoswald:master#diff-d9af7bfb35fcf05f035686555259bb94R141 fits in with your patterns, if there is a better to ensure the process exits let me know.