### PR TITLE
Add support of boolean expressions to select migrations in --tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,14 @@ you can pass `--force` option to execute already executed migrations.
 This is useful while you develop and test your migration.
 
 You also can export `tags` array from migration and then migrate only
-migrations with selected tag specified by `--tag` option.
+migrations that satisfied expression specified by `--tag` option. Expression
+consists of tag names and boolean operators `&`, `|` and `!`. For example,
+following command will migrate all migrations that have tag `tag1` and not have
+tag `tag2`:
+
+```sh
+east migrate --tag 'tag1 & !tag2'
+```
 
 ### rollback
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ you can pass `--force` option to execute already executed migrations.
 This is useful while you develop and test your migration.
 
 You also can export `tags` array from migration and then migrate only
-migrations that satisfied expression specified by `--tag` option. Expression
+migrations that satisfied expression specified by option `--tag`. Expression
 consists of tag names and boolean operators `&`, `|` and `!`. For example,
 following command will migrate all migrations that have tag `tag1` and not have
 tag `tag2`:

--- a/bin/east
+++ b/bin/east
@@ -80,20 +80,26 @@ var actionCommandAsyncAction = function(names, command, callback) {
 program
 	.command(new MigrateCommand('migrate [migrations...]'))
 	.option('-f, --force', 'force to execute already executed migrations')
-	.option('-t, --tag <value>', 'execute only migrations with selected tag')
+	.option(
+		'-t, --tag <expression>', 'execute only migrations that satisfied expression'
+	)
 	.description('run all or selected migrations')
 	.asyncAction(actionCommandAsyncAction);
 
 program
 	.command(new RollbackCommand('rollback [migrations...]'))
 	.option('-f, --force', 'force to rollback not yet executed migrations')
-	.option('-t, --tag <value>', 'rollback only migrations with selected tag')
+	.option(
+		'-t, --tag <expression>', 'rollback only migrations that satisfied expression'
+	)
 	.description('rollback all or selected migrations')
 	.asyncAction(actionCommandAsyncAction);
 
 program
 	.command(new ListCommand('list [status]'))
-	.option('-t, --tag <value>', 'list only migrations with selected tag')
+	.option(
+		'-t, --tag <expression>', 'list only migrations that satisfied expression'
+	)
 	.description(
 		'list migration with selected status (`new`, `executed` or `all`), ' +
 		'`new` by default'

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -218,11 +218,13 @@ Migrator.prototype._filterMigrationNamesByTag = function(params, callback) {
 				operators: utils.booleanOperators
 			});
 			migrations.forEach(function(migration) {
-				if (evalTagExpression({
+				var expressionResult = evalTagExpression({
 					parseOperand: function(operand) {
 						return migration.tags && migration.tags.indexOf(operand) !== -1;
 					}
-				})) {
+				});
+
+				if (expressionResult) {
 					names.push(migration.name);
 				}
 			});

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -4,7 +4,8 @@ var path = require('path'),
 	fs = require('fs'),
 	ProgressBar = require('progress'),
 	utils = require('./utils'),
-	Steppy = require('twostep').Steppy;
+	Steppy = require('twostep').Steppy,
+	expressionify = require('expressionify');
 
 /**
  * Main class
@@ -213,8 +214,15 @@ Migrator.prototype._filterMigrationNamesByTag = function(params, callback) {
 		},
 		function(err) {
 			var names = [];
+			var evalTagExpression = expressionify(params.tag, {
+				operators: utils.booleanOperators
+			});
 			migrations.forEach(function(migration) {
-				if (migration.tags && migration.tags.indexOf(params.tag) !== -1) {
+				if (evalTagExpression({
+					parseOperand: function(operand) {
+						return migration.tags && migration.tags.indexOf(operand) !== -1;
+					}
+				})) {
 					names.push(migration.name);
 				}
 			});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,3 +25,22 @@ exports.extend = function(dst, src) {
 };
 
 exports.keys = Object.keys;
+
+// operators for expressionify lib
+exports.booleanOperators = {
+	'|': {
+		execute: function(x, y) { return x || y; },
+		priority: 1,
+		type: 'binary'
+	},
+	'&': {
+		execute: function(x, y) { return x && y; },
+		priority: 2,
+		type: 'binary'
+	},
+	'!': {
+		execute: function(x) { return !x; },
+		priority: 3,
+		type: 'unary'
+	}
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "commander": "2.9.0",
+    "expressionify": "0.9.1",
     "progress": "1.1.8",
     "twostep": "0.4.1"
   },

--- a/test/migrator.js
+++ b/test/migrator.js
@@ -501,6 +501,57 @@ describe('migrator', function() {
 				);
 			});
 
+			it('should get migrations with tags one or two', function(done) {
+				Steppy(
+					function() {
+						migrator.filterMigrationNames({
+							by: 'tag',
+							names: utils.keys(migrationNamesHash),
+							tag: 'one | two'
+						}, this.slot());
+					},
+					function(err, filterResult) {
+						expect(filterResult).eql({names: ['one', 'two']});
+						this.pass(null);
+					},
+					done
+				);
+			});
+
+			it('should get migrations with tags one and two', function(done) {
+				Steppy(
+					function() {
+						migrator.filterMigrationNames({
+							by: 'tag',
+							names: utils.keys(migrationNamesHash),
+							tag: 'one & two'
+						}, this.slot());
+					},
+					function(err, filterResult) {
+						expect(filterResult).eql({names: ['two']});
+						this.pass(null);
+					},
+					done
+				);
+			});
+
+			it('should get migrations without tag two', function(done) {
+				Steppy(
+					function() {
+						migrator.filterMigrationNames({
+							by: 'tag',
+							names: utils.keys(migrationNamesHash),
+							tag: '!two'
+						}, this.slot());
+					},
+					function(err, filterResult) {
+						expect(filterResult).eql({names: ['one', 'three', '9999_test']});
+						this.pass(null);
+					},
+					done
+				);
+			});
+
 			after(function() {
 				Migrator.prototype.loadMigration = loadMigration;
 			});


### PR DESCRIPTION
`--tag` option now can get an expression with boolean operators to select migrations by tags more flexible. For evaluating expressions used [Expressionify](https://github.com/2do2go/expressionify). Readme and tests updated.