### PR TITLE
Support adaptor specific params passed by object

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -28,7 +28,7 @@ function Migrator(params) {
 
 	// param precedence:
 	// params config overrides resource config overrides default config
-	self.params = Object.assign(defaults, self._loadConfig(params.config), params);
+	self.params = utils.assign(defaults, self._loadConfig(params.config), params);
 
 	// create adapter
 	self.adapter = self._createAdapter(self.params.adapter, self.params);

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -28,9 +28,7 @@ function Migrator(params) {
 
 	// param precedence:
 	// params config overrides resource config overrides default config
-	self.params = Object.assign(defaults,
-    	self._loadConfig(params.config),
-		params);
+	self.params = Object.assign(defaults, self._loadConfig(params.config), params);
 
 	// create adapter
 	self.adapter = self._createAdapter(self.params.adapter, self.params);

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -14,7 +14,6 @@ function Migrator(params) {
 	params = params || {};
 	var self = this;
 	// merge parameters
-	self.params = self._loadConfig(params.config);
 	var defaults = {
 		// migrations dir
 		dir: path.resolve('migrations'),
@@ -26,10 +25,13 @@ function Migrator(params) {
 		url: null,
 		trace: false
 	};
-	utils.keys(defaults).forEach(function(key) {
-		if (key in params) self.params[key] = params[key];
-		if (key in self.params === false) self.params[key] = defaults[key];
-	});
+
+	// param precedence:
+	// params config overrides resource config overrides default config
+	self.params = Object.assign(defaults,
+    	self._loadConfig(params.config),
+		params);
+
 	// create adapter
 	self.adapter = self._createAdapter(self.params.adapter, self.params);
 	// get default path to migration template from adapter

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,10 +21,12 @@ exports.slice = function() {
 	return Array.prototype.slice.apply(array, arguments);
 };
 
-exports.extend = function(dst, src) {
+function extend(dst, src) {
 	for (var key in src) {dst[key] = src[key];}
 	return dst;
-};
+}
+
+exports.extend = extend;
 
 exports.keys = Object.keys;
 
@@ -46,3 +48,16 @@ exports.booleanOperators = {
 		type: 'unary'
 	}
 };
+
+function assign() {
+	var dest = {};
+
+	do {
+		var src = arguments.shift();
+		extend(dest, src);
+	} while(arguments.length > 0);
+
+	return dest;
+};
+
+exports.assign = (Object.assign === undefined ? assign : Object.assign);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,11 +51,12 @@ exports.booleanOperators = {
 
 function assign() {
 	var dest = {};
+    var args = Array.prototype.slice.call(arguments);
 
 	do {
-		var src = arguments.shift();
+		var src = args.shift();
 		extend(dest, src);
-	} while(arguments.length > 0);
+	} while(args.length > 0);
 
 	return dest;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,6 +58,6 @@ function assign() {
 	} while(arguments.length > 0);
 
 	return dest;
-};
+}
 
 exports.assign = (Object.assign === undefined ? assign : Object.assign);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,7 +51,7 @@ exports.booleanOperators = {
 
 function assign() {
 	var dest = {};
-    var args = Array.prototype.slice.call(arguments);
+	var args = Array.prototype.slice.call(arguments);
 
 	do {
 		var src = args.shift();


### PR DESCRIPTION
The previous implementation of parameter setting would not allow adaptor specific parameters (such as `createDbOnConnect` for `mysql-east`) from being specified as part of the params object. Instead a eastrc file was required to specify that value.

Using east as part of my test suite, I would prefer to configure Migrator only with a params object and not have to create a config file.

This change allows:
```js
const Migrator = require('east');
let east = new Migrator({
  createDbOnConnect: true, // pr adds support for this key
  url: 'mysql://...',
  adapter: 'east-mysql'
});
```