### PR TITLE
Config adapter constructor

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -74,9 +74,9 @@ Migrator.prototype._tryLoadAdapter = function(path) {
 Migrator.prototype._createAdapter = function(adapterPath, params) {
 	if(typeof adapterPath === 'function') {
 		try {
-            return new adapterPath(params);
+			return new adapterPath(params);
 		} catch (err) {
-			throw new Error("Error constructing adapter:" + err.message);
+			throw new Error('Error constructing adapter:' + err.message);
 		}
 	}
 	// try load adapter from migrator-related path first then from cwd-related

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -72,6 +72,13 @@ Migrator.prototype._tryLoadAdapter = function(path) {
 };
 
 Migrator.prototype._createAdapter = function(adapterPath, params) {
+	if(typeof adapterPath === 'function') {
+		try {
+            return new adapterPath(params);
+		} catch (err) {
+			throw new Error("Error constructing adapter:" + err.message);
+		}
+	}
 	// try load adapter from migrator-related path first then from cwd-related
 	var paths = [adapterPath, path.join(process.cwd(), adapterPath)],
 		Adapter,


### PR DESCRIPTION
The previous strategy of dynamically loading adapters at runtime (when Migrator is constructed and calls `_createAdapter`) doesn't work in a browserify/webpack environment. 

This change allows a consumer of `Migrator` to load their adapter ahead of time (`let Adapter = require('east-mysql');`) and provide the constructor to `Migrator`. This allows compatible with webpack/browserify by making the require module call visible at build time.


This change allows:

```js
const Migrator = require('east');
const Adapter = require('east-mysql');
let east = new Migrator({
  url: 'mysql://...',
  adapter: Adapter
});
```