### PR TITLE
Add option to create migration files with date time derived prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,29 @@ exports.rollback = function(client, done) {
 
 or you can use special adapter for database (see [adapters](#adapters) section)
 
+#### Migration file number format
+
+The default format for migration file names is to prepend a number to the filename which is incremented with every
+new file. This creates migration files such as `migrations/1_doSomething.js`, `migrations/2_doSomethingElse.js`.
+
+If you prefer your files to be created with a timestap instead of sequential numbers, you can set the
+`migrationNumberFormat` configuration parameter in your `.eastrc` to `dateTime`:
+
+```json
+{
+    "migrationNumberFormat": "dateTime"
+}
+```
+
+This will create migration files such as `migrations/20190720172730_doSomething.js`.
+
+For the default behaviour, you can omit the `migrationNumberFormat` configuration option or set it to:
+```json
+{
+    "migrationNumberFormat": "sequentialNumber"
+}
+```
+
 ### migrate
 
 let's create one more migration

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -32,6 +32,8 @@ Migrator.prototype.configure = function configure(params) {
 				adapter: './adapter',
 				// db url
 				url: null,
+				// number format for migration filenames
+				migrationNumberFormat: 'sequentialNumber',
 				trace: false
 			};
 
@@ -261,7 +263,27 @@ Migrator.prototype._getBaseName = function _getBaseName(name) {
 	return this._nameRegExp.exec(name)[2];
 };
 
-Migrator.prototype._getNextNumber = function _getNextNumber() {
+Migrator.prototype._zeroPadNumber = function _zeroPadNumber(number, padding) {
+	let paddedNumber = number.toString();
+	while (paddedNumber.length < padding) {
+		paddedNumber = `0${paddedNumber}`;
+	}
+	return paddedNumber;
+};
+
+Migrator.prototype._getDateTimeNumber = function _getDateTimeNumber() {
+	const now = new Date();
+	return Promise.resolve(
+		now.getFullYear().toString() +
+		this._zeroPadNumber(now.getMonth() + 1, 2) +
+		this._zeroPadNumber(now.getDate(), 2) +
+		this._zeroPadNumber(now.getHours(), 2) +
+		this._zeroPadNumber(now.getMinutes(), 2) +
+		this._zeroPadNumber(now.getSeconds(), 2)
+	);
+};
+
+Migrator.prototype._getSequentialNumber = function _getSequentialNumber() {
 	return Promise.resolve()
 		.then(() => {
 			return this.getAllMigrationNames();
@@ -272,6 +294,19 @@ Migrator.prototype._getNextNumber = function _getNextNumber() {
 
 			return num;
 		});
+};
+
+Migrator.prototype._getNextNumber = function _getNextNumber() {
+	if (this.params.migrationNumberFormat === 'dateTime') {
+		return this._getDateTimeNumber();
+	} else if (this.params.migrationNumberFormat === 'sequentialNumber') {
+		return this._getSequentialNumber();
+	} else {
+		throw new Error(
+			`Unrecognised number format: "${this.params.migrationNumberFormat}".\n` +
+			'Supported values are "dateTime" and "sequentialNumber"'
+		);
+	}
 };
 
 Migrator.prototype.getNewMigrationNames = function getNewMigrationNames() {


### PR DESCRIPTION
Because we have a number of people working on our project at once, it is helpful to use timestamp-related migration prefixes (similar to Rails) instead of sequential numbers. This prevents two people working on different branches generating a migration file with the same prefix.

This adds a `numberFormat` configuration setting that, when set to `timestamp` causes new migrations to be created with a timestamp-derived number (`yyyymmddHHMMSS`) instead of a sequential one.

I implemented a timestamp-generation method manually so as not to have to depend on any additional npm modules.