### PR TITLE
Use extension of the template file when creating a migration

### DIFF
--- a/lib/migrator/methods/create.js
+++ b/lib/migrator/methods/create.js
@@ -10,9 +10,9 @@ module.exports = function create(baseName) {
 			return this._getNextNumber();
 		})
 		.then((num) => {
-      const name = `${num}_${baseName}`;
-      const extName = pathUtils.extname(this.params.template);
-      const path = replaceExt(this.getMigrationPathByName(name), extName);
+      			const name = `${num}_${baseName}`;
+      			const extName = pathUtils.extname(this.params.template);
+     			const path = replaceExt(this.getMigrationPathByName(name), extName);
 
 			return pProps({
 				name,

--- a/lib/migrator/methods/create.js
+++ b/lib/migrator/methods/create.js
@@ -10,9 +10,9 @@ module.exports = function create(baseName) {
 			return this._getNextNumber();
 		})
 		.then((num) => {
-		const name = `${num}_${baseName}`;
-      		const extName = pathUtils.extname(this.params.template);
-     			const path = replaceExt(this.getMigrationPathByName(name), extName);
+			const name = `${num}_${baseName}`;
+			const extName = pathUtils.extname(this.params.template);
+			const path = replaceExt(this.getMigrationPathByName(name), extName);
 
 			return pProps({
 				name,

--- a/lib/migrator/methods/create.js
+++ b/lib/migrator/methods/create.js
@@ -10,8 +10,8 @@ module.exports = function create(baseName) {
 			return this._getNextNumber();
 		})
 		.then((num) => {
-      			const name = `${num}_${baseName}`;
-      			const extName = pathUtils.extname(this.params.template);
+		const name = `${num}_${baseName}`;
+      		const extName = pathUtils.extname(this.params.template);
      			const path = replaceExt(this.getMigrationPathByName(name), extName);
 
 			return pProps({

--- a/lib/migrator/methods/create.js
+++ b/lib/migrator/methods/create.js
@@ -2,6 +2,7 @@
 
 const fse = require('fs-extra');
 const pProps = require('p-props');
+const pathUtils = require('path');
 
 module.exports = function create(baseName) {
 	return Promise.resolve()
@@ -9,8 +10,9 @@ module.exports = function create(baseName) {
 			return this._getNextNumber();
 		})
 		.then((num) => {
-			const name = `${num}_${baseName}`;
-			const path = this.getMigrationPathByName(name);
+      const name = `${num}_${baseName}`;
+      const extName = pathUtils.extname(this.params.template);
+      const path = replaceExt(this.getMigrationPathByName(name), extName);
 
 			return pProps({
 				name,
@@ -19,3 +21,8 @@ module.exports = function create(baseName) {
 		})
 		.then((result) => result.name);
 };
+
+function replaceExt(path, ext) {
+  const fileName = pathUtils.basename(path, pathUtils.extname(path)) + ext;
+  return pathUtils.join(pathUtils.dirname(path), fileName);
+}


### PR DESCRIPTION
Hi! This is a very nice tool to use. Though there is one inconvenience with it. It doesn't support transpiled languages like TypeScript.
It would be great if there was an option like `"createDir"` apart from just `"dir"` in `.eastrc` to specify where the template file goes when creating a migration, because otherwise it goes to the `build` dir with compiled JavaScript files...
Anyway this PR solves a small inconvenience where my adapter for Elasticsearch specifies a path to `template.ts`, but when I run
`east create my-migration --dir src/migrations` it is created as `1_my-migration.js` instead, which is annoying.