### PR TITLE
Add east-dynamodb to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Other adapters:
 * [mysql](https://github.com/riggerthegeek/east-mysql)
 * [couchbase](https://github.com/ramiel/east-couchbase)
 * [couchdb](https://github.com/schipiga/east-couchdb)
+* [dynamodb](https://github.com/cstar-industries/east-dynamodb)
 
 
 ## Plugins


### PR DESCRIPTION
I created an adapter for AWS DynamoDB.

https://github.com/cstar-industries/east-dynamodb

I'd love to see it added to the official list of adapters in the `east` documentation.