### PR TITLE
fix: load config using ES modules

### DIFF
--- a/lib/migrator/methods/configure.js
+++ b/lib/migrator/methods/configure.js
@@ -25,7 +25,7 @@ module.exports = function configure(params = {}) {
 				// whether to load or not config file
 				loadConfig: _(params).has('loadConfig') ? params.loadConfig : true,
 				// whether to support es modules or not
-				esModules: false
+				esModules: _(params).has('esModules') ? params.esModules : false
 			};
 
 			if (this.params.loadConfig) {


### PR DESCRIPTION
Currently, if the config is an ES module, it will try to load it using cjs instead because it wasn't reading the value of `esModules` from params

Steps to reproduce:

```sh
mkdir my-proj
cd my-proj
```

```js
// .eastrc.mjs
import path from 'path';
export const dir = path.resolve('deploy-once');
```

Run `npx east --es-modules --config .eastrc.mjs create muhaha`

Error
```
Error while loading config "my-proj/.eastrc.mjs" as json:
SyntaxError: Unexpected token / in JSON at position 0
    at JSON.parse (<anonymous>)
    at my-proj/node_modules/east/lib/migrator/methods/_loadConfig.js:26:33
    at async Promise.all (index 0)

and as module:
Error: Error loading module "my-proj/.eastrc.mjs":
 Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: my-proj/.eastrc.mjs
    at Module.load (internal/modules/cjs/loader.js:926:11)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at my-proj/node_modules/east/lib/migrator/methods/_loadModule.js:7:42
    at my-proj/node_modules/east/lib/migrator/methods/_loadModule.js:21:10
    at async Promise.all (index 0)
```