### PR TITLE
Test: Add more tests for config formats

### DIFF
--- a/tap-snapshots/test-02-snapshot-bin-east-commands-init-withCjsModuleConfig.js-TAP.test.js
+++ b/tap-snapshots/test-02-snapshot-bin-east-commands-init-withCjsModuleConfig.js-TAP.test.js
@@ -1,0 +1,26 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/02-snapshot/bin/east/commands/init/withCjsModuleConfig.js TAP > output 1`] = `
+Current parameters: {
+    "dir": "[Migrations dir]",
+    "migrationExtension": "js",
+    "sourceDir": "[Migrations dir]",
+    "sourceMigrationExtension": "js",
+    "timeout": 123456789,
+    "adapter": "[Adapter path]",
+    "url": null,
+    "migrationNumberFormat": "sequentialNumber",
+    "trace": true,
+    "loadConfig": true,
+    "esModules": false,
+    "config": "[Config path]",
+    "template": "[Migration template]"
+}
+initialization successfully done, migration files will be stored at "[Migrations dir]"
+
+`

--- a/tap-snapshots/test-02-snapshot-bin-east-commands-init-withEsModuleConfig.js-TAP.test.js
+++ b/tap-snapshots/test-02-snapshot-bin-east-commands-init-withEsModuleConfig.js-TAP.test.js
@@ -1,0 +1,26 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/02-snapshot/bin/east/commands/init/withEsModuleConfig.js TAP > output 1`] = `
+Current parameters: {
+    "dir": "[Migrations dir]",
+    "migrationExtension": "js",
+    "sourceDir": "[Migrations dir]",
+    "sourceMigrationExtension": "js",
+    "timeout": 123456789,
+    "adapter": "[Adapter path]",
+    "url": null,
+    "migrationNumberFormat": "sequentialNumber",
+    "trace": true,
+    "loadConfig": true,
+    "esModules": true,
+    "config": "[Config path]",
+    "template": "[Migration template]"
+}
+initialization successfully done, migration files will be stored at "[Migrations dir]"
+
+`

--- a/tap-snapshots/test-02-snapshot-bin-east-commands-init-withJsonConfig.js-TAP.test.js
+++ b/tap-snapshots/test-02-snapshot-bin-east-commands-init-withJsonConfig.js-TAP.test.js
@@ -1,0 +1,26 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/02-snapshot/bin/east/commands/init/withJsonConfig.js TAP > output 1`] = `
+Current parameters: {
+    "dir": "[Migrations dir]",
+    "migrationExtension": "js",
+    "sourceDir": "[Migrations dir]",
+    "sourceMigrationExtension": "js",
+    "timeout": 123456789,
+    "adapter": "[Adapter path]",
+    "url": null,
+    "migrationNumberFormat": "sequentialNumber",
+    "trace": true,
+    "loadConfig": true,
+    "esModules": false,
+    "config": "[Config path]on",
+    "template": "[Migration template]"
+}
+initialization successfully done, migration files will be stored at "[Migrations dir]"
+
+`

--- a/test/02-snapshot/bin/east/commands/init/withCjsModuleConfig.js
+++ b/test/02-snapshot/bin/east/commands/init/withCjsModuleConfig.js
@@ -12,7 +12,7 @@ if (!testUtils.isEsmSupported()) {
 	tap.grep = [/.*/];
 }
 
-const describeTitle = 'bin/east init with es module config';
+const describeTitle = 'bin/east init with cjs module config';
 
 describe(describeTitle, () => {
 	let commandResult;
@@ -30,10 +30,10 @@ describe(describeTitle, () => {
 	before(() => {
 		return Promise.resolve()
 			.then(() => {
-				configPath = pathUtils.join(testEnv.dir, '.eastrc.mjs');
+				configPath = pathUtils.join(testEnv.dir, '.eastrc.js');
 				return fs.promises.writeFile(
 					configPath,
-					'export default {timeout: 123456789};',
+					'module.exports = {timeout: 123456789};',
 					'utf-8'
 				);
 			});
@@ -49,7 +49,7 @@ describe(describeTitle, () => {
 				const binPath = testUtils.getBinPath('east');
 
 				return testUtils.execAsync(
-					`"${binPath}" init --config "${configPath}" --trace --es-modules`,
+					`"${binPath}" init --config "${configPath}" --trace`,
 					{cwd: testEnv.dir}
 				);
 			})

--- a/test/02-snapshot/bin/east/commands/init/withEsModuleConfig.js
+++ b/test/02-snapshot/bin/east/commands/init/withEsModuleConfig.js
@@ -1,0 +1,69 @@
+const tap = require('tap');
+const expect = require('expect.js');
+const fs = require('fs');
+const pathUtils = require('path');
+const testUtils = require('../../../../../../testUtils');
+
+tap.mochaGlobals();
+
+// skip this test if es modules are not supported
+if (!testUtils.isEsmSupported()) {
+	tap.grepInvert = 1;
+	tap.grep = [/.*/];
+}
+
+const describeTitle = 'bin/east init with es module config';
+
+describe(describeTitle, () => {
+	let commandResult;
+	let testEnv;
+	let configPath;
+
+	before(() => {
+		return Promise.resolve()
+			.then(() => testUtils.createEnv())
+			.then((createdTestEnv) => {
+				testEnv = createdTestEnv;
+			});
+	});
+
+	before(() => {
+		return Promise.resolve()
+			.then(() => {
+				configPath = pathUtils.join(testEnv.dir, 'eastrc.mjs');
+				return fs.promises.writeFile(
+					configPath,
+					'export default {timeout: 123456789};',
+					'utf-8'
+				);
+			});
+	});
+
+	after(() => fs.promises.unlink(configPath));
+
+	after(() => testUtils.destroyEnv(testEnv));
+
+	it('should be done without error', () => {
+		return Promise.resolve()
+			.then(() => {
+				const binPath = testUtils.getBinPath('east');
+
+				return testUtils.execAsync(
+					`"${binPath}" init --config "${configPath}" --trace --es-modules`,
+					{cwd: testEnv.dir}
+				);
+			})
+			.then((result) => {
+				expect(result.stderr).not.ok();
+
+				commandResult = result;
+			});
+	});
+
+	it('stdout should match expected snapshot', () => {
+		tap.matchSnapshot(
+			testUtils.cleanSnapshotData(commandResult.stdout),
+			'output'
+		);
+	});
+});

--- a/test/02-snapshot/bin/east/commands/init/withJsonConfig.js
+++ b/test/02-snapshot/bin/east/commands/init/withJsonConfig.js
@@ -1,0 +1,69 @@
+const tap = require('tap');
+const expect = require('expect.js');
+const fs = require('fs');
+const pathUtils = require('path');
+const testUtils = require('../../../../../../testUtils');
+
+tap.mochaGlobals();
+
+// skip this test if es modules are not supported
+if (!testUtils.isEsmSupported()) {
+	tap.grepInvert = 1;
+	tap.grep = [/.*/];
+}
+
+const describeTitle = 'bin/east init with json config';
+
+describe(describeTitle, () => {
+	let commandResult;
+	let testEnv;
+	let configPath;
+
+	before(() => {
+		return Promise.resolve()
+			.then(() => testUtils.createEnv())
+			.then((createdTestEnv) => {
+				testEnv = createdTestEnv;
+			});
+	});
+
+	before(() => {
+		return Promise.resolve()
+			.then(() => {
+				configPath = pathUtils.join(testEnv.dir, '.eastrc.json');
+				return fs.promises.writeFile(
+					configPath,
+					'{"timeout": 123456789}',
+					'utf-8'
+				);
+			});
+	});
+
+	after(() => fs.promises.unlink(configPath));
+
+	after(() => testUtils.destroyEnv(testEnv));
+
+	it('should be done without error', () => {
+		return Promise.resolve()
+			.then(() => {
+				const binPath = testUtils.getBinPath('east');
+
+				return testUtils.execAsync(
+					`"${binPath}" init --config "${configPath}" --trace`,
+					{cwd: testEnv.dir}
+				);
+			})
+			.then((result) => {
+				expect(result.stderr).not.ok();
+
+				commandResult = result;
+			});
+	});
+
+	it('stdout should match expected snapshot', () => {
+		tap.matchSnapshot(
+			testUtils.cleanSnapshotData(commandResult.stdout),
+			'output'
+		);
+	});
+});

--- a/testUtils/cleanSnapshotData.js
+++ b/testUtils/cleanSnapshotData.js
@@ -15,7 +15,7 @@ const adapterPathRegExp = new RegExp(
 	'g'
 );
 const configPathRegExp = new RegExp(
-	'/.+?/eastrc(\\.mjs)?',
+	'/.+?/\\.eastrc(\\.js|\\.json|\\.mjs)?',
 	'g'
 );
 

--- a/testUtils/cleanSnapshotData.js
+++ b/testUtils/cleanSnapshotData.js
@@ -14,6 +14,10 @@ const adapterPathRegExp = new RegExp(
 	'/.+?/adapter\\.js',
 	'g'
 );
+const configPathRegExp = new RegExp(
+	'/.+?/eastrc(\\.mjs)?',
+	'g'
+);
 
 module.exports = (data) => {
 	return (
@@ -21,5 +25,6 @@ module.exports = (data) => {
 			.replace(migrationTemplateRegExp, '[Migration template]')
 			.replace(eastStackTraceRegExp, '[East source stack trace]')
 			.replace(adapterPathRegExp, '[Adapter path]')
+			.replace(configPathRegExp, '[Config path]')
 	);
 };


### PR DESCRIPTION
This PR brings some snapshot tests for config in different formats.
https://github.com/okv/east/pull/83 pointed out that such tests are missing. 